### PR TITLE
Remove circular dependency from setup, add additional dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,13 @@ def main():
             scripts = glob('bin/*'),
             install_requires = ['pandas',
                                 'numpy',
+                                'matplotlib',
+                                'doit',
+                                'ficus'
                                 ],
             zip_safe = False,
             include_package_data = True,
             cmdclass = cmdclass  )
-        
+
 if __name__ == "__main__":
     main()

--- a/shmlast/__init__.py
+++ b/shmlast/__init__.py
@@ -1,7 +1,1 @@
-from . import crbl
-from . import util
-from . import hits
-from . import last
-from . import transeq
-
 __version__ = '0.1'


### PR DESCRIPTION
The circular dependency happens when you try to install the package without one of the needed dependencies (`seaborn` or `matplotlib`, for example) already in the virtualenv.

Also adds the additional dependencies to `install_requires`
